### PR TITLE
Improvement to readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
-Set your Github Personal Token inside the environment variable `GITHUB_TOKEN`
+Set your Github Personal Token inside the environment variable `GITHUB_TOKEN`. Check [here](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) on how to create one.
+
+Edit ```stack.yml```, on ```image: kenfdev/github-stats``` change ```kenfdev``` for your DockerHub user.
+
+Deploy with
+```bash
+$ faas-cli up
+```
 
 Make a request with an organization name:
 


### PR DESCRIPTION
Added some instructions to make it work. 

If for some reason the local build fails, faas-cli deploy downloads the image from DockeHub, which is broken currently. The code in the image is intended to read the GITHUB_TOKEN from a secret, but is incomplete.

Signed-off-by: Patricio Diaz <padiazg@gmail.com>